### PR TITLE
feat: compress data in an optimized qr code

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -7,28 +7,24 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   try {
     const response = await getLinkToken();
-    const linkToken = response.data; // Extract token from response
+    const linkToken = response.data;
     console.log('Link token received:', linkToken);
-
-    const deepLink = `${APP_LINK}/--/connect?token=${linkToken}`;
-    const tokenOnlyUrl = `token-${linkToken}`;
     const deviceName = navigator.userAgent;
     const decryptionKey = await getEncryptionKey();
+    if (!decryptionKey) throw new Error('Failed to get encryption key');
 
-    const combinedData = JSON.stringify({
-      app: deepLink,
-      token: tokenOnlyUrl,
-      name: deviceName,
-      decryptionKey: decryptionKey,
-    });
+    // we encode everything in URL to avoid duplicates and allow our app to retrieve everything
+    const deepLink = `${APP_LINK}/--/connect?t=${linkToken}&n=${deviceName}&d=${decryptionKey.k}`;
 
-    const qrCodeDataUrl = await QRCode.toDataURL(combinedData, {
+    const qrCodeDataUrl = await QRCode.toDataURL(deepLink, {
       width: 200,
       margin: 2,
       color: {
         dark: '#000000',
         light: '#ffffff',
       },
+      // in this context it's better to have a readable qrcode than a recoverable code
+      errorCorrectionLevel: 'L',
     });
     console.log('QR code generated successfully');
 


### PR DESCRIPTION
This pr reduces what is stored in the qrcode and uses an optimized representation when possible.

Instead of sending a json (non standard) it only sends an URL with the various params, this way:
- it will work with android and other qr code scanners
- it won't contain the same data twice (simpler qrcode)
- it will support passing data to the app when opening it from the camera app on iPhone